### PR TITLE
1) Supported -> Supported? 2) Objects? -> Objects

### DIFF
--- a/destinations/activecampaign.md
+++ b/destinations/activecampaign.md
@@ -139,7 +139,7 @@ Census will return an error if the list with the matching ID cannot be found. If
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |    Contact   |

--- a/destinations/airtable.md
+++ b/destinations/airtable.md
@@ -141,7 +141,7 @@ Airtable needs a primary key that is a short text field for Census to be able to
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |      All     |

--- a/destinations/algolia.md
+++ b/destinations/algolia.md
@@ -114,7 +114,7 @@ Algolia stores data within collections called Indices. Your Indices in Algolia c
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |     Index    |
 

--- a/destinations/alloydb.md
+++ b/destinations/alloydb.md
@@ -55,7 +55,7 @@ After the connection is verified, you all tables will be exposed, but please tak
 
 We support syncing data to Tables in AlloyDB, but they must have a uniqueness constraint on a column. ​
 
-| **Object Name** | **Supported** |                   **Identifiers**                   |
+| **Object Name** | **Supported?** |                   **Identifiers**                   |
 | :-------------: | :-----------: | :-------------------------------------------------: |
 |      Table      |       ✅       | Primary Keys or Columns with Uniqueness Constraints |
 
@@ -65,7 +65,7 @@ We support syncing data to Tables in AlloyDB, but they must have a uniqueness co
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 |           **Update** |        ✅       |      All     |
 | **Update or Create** |        ✅       |      All     |

--- a/destinations/amplitude.md
+++ b/destinations/amplitude.md
@@ -132,7 +132,7 @@ As a result of this behavior, we often get asked "Why can't I see my user proper
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |     **Objects?**    |
+|        **Behaviors** | **Supported?** |     **Objects**    |
 | -------------------: | :------------: | :-----------------: |
 | **Update or Create** |        ✅       | Device, User, Group |
 |           **Append** |        ✅       |        Event        |

--- a/destinations/anaplan (1).md
+++ b/destinations/anaplan (1).md
@@ -71,7 +71,7 @@ Import Actions must have the Source Type of File in order for Census to be able 
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ------------: | :------------: | :----------: |
 |    **Mirror** |        ✅       |      All     |
 

--- a/destinations/apollo.md
+++ b/destinations/apollo.md
@@ -135,7 +135,7 @@ Census currently supports syncing to the following Apollo objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** |                       **Supported?**                      |   **Objects?**   |
+|        **Behaviors** |                       **Supported?**                      |   **Objects**   |
 | -------------------: | :-------------------------------------------------------: | :--------------: |
 | **Update or Create** | [✅](https://docs.getcensus.com/basics/alerts#sync-alerts) | Account, Contact |
 |      **Update Only** |                             ✅                             | Account, Contact |

--- a/destinations/appcues.md
+++ b/destinations/appcues.md
@@ -85,7 +85,7 @@ Census currently supports syncing to the following Appcues objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |     User     |
 

--- a/destinations/asana.md
+++ b/destinations/asana.md
@@ -39,7 +39,7 @@ You will be redirected to a page to log in to Asana to authorize access to your 
 
 Asana's primary object is a Task, which we support in Census.​
 
-| **Object Name** | **Supported** | **Identifiers** |
+| **Object Name** | **Supported?** | **Identifiers** |
 | :-------------: | :-----------: | :-------------: |
 |       Task      |       ✅       |   External ID   |
 
@@ -49,7 +49,7 @@ Asana's primary object is a Task, which we support in Census.​
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |     Task     |
 

--- a/destinations/autopilot-journeys.md
+++ b/destinations/autopilot-journeys.md
@@ -116,7 +116,7 @@ That's it! In 6 steps, you connected Census to Autopilot and started syncing cus
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 

--- a/destinations/braze.md
+++ b/destinations/braze.md
@@ -132,7 +132,7 @@ Only the Braze User External Id and the Subscription Group Id should be mapped f
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** |                       **Supported?**                      |                                     **Objects?**                                     |
+|        **Behaviors** |                       **Supported?**                      |                                     **Objects**                                     |
 | -------------------: | :-------------------------------------------------------: | :----------------------------------------------------------------------------------: |
 | **Update or Create** | [✅](https://docs.getcensus.com/basics/alerts#sync-alerts) |                                         User                                         |
 |           **Mirror** |                             ✅                             | User, [Subscription Group Membership](braze.md#braze-subscription-group-memberships) |

--- a/destinations/chargebee.md
+++ b/destinations/chargebee.md
@@ -58,7 +58,7 @@ Census currently supports syncing to the following Chargebee objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|   **Behaviors** | **Supported?** |      **Objects?**      |
+|   **Behaviors** | **Supported?** |      **Objects**      |
 | --------------: | :------------: | :--------------------: |
 | **Update Only** |        ✅       | Customer, Subscription |
 

--- a/destinations/chargify.md
+++ b/destinations/chargify.md
@@ -130,7 +130,7 @@ Census currently supports syncing to the following Chargify objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ------------: | :------------: | :----------: |
 |    **Append** |        ✅       |     Event    |
 

--- a/destinations/chartmogul.md
+++ b/destinations/chartmogul.md
@@ -116,7 +116,7 @@ Syncs to the ChartMogul **Customer** object require both the Data Source ID and 
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |     **Objects?**     |
+|        **Behaviors** | **Supported?** |     **Objects**     |
 | -------------------: | :------------: | :------------------: |
 | **Update or Create** |        ✅       |       Customer       |
 |           **Update** |        ✅       |       Customer       |

--- a/destinations/criteo.md
+++ b/destinations/criteo.md
@@ -79,7 +79,7 @@ And if anything went wrong, contact the [Census support team](mailto:support@get
 
 ## 🗄 Supported objects
 
-|        **Object Name** | **Supported** | **Identifiers**                                            |
+|        **Object Name** | **Supported?** | **Identifiers**                                            |
 | ---------------------: | :-----------: | ---------------------------------------------------------- |
 | Static List Membership |       ✅       | GUM Cookie ID, Mobile Ad ID, Email, LiveRamp Identity Link |
 
@@ -87,7 +87,7 @@ And if anything went wrong, contact the [Census support team](mailto:support@get
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** |       **Objects**      |
+|     **Behavior** | **Supported?** |       **Objects**      |
 | ---------------: | :-----------: | :--------------------: |
 | Update or Create |       ✅       | Static List Membership |
 |           Mirror |       ✅       | Static List Membership |

--- a/destinations/customer.io.md
+++ b/destinations/customer.io.md
@@ -111,7 +111,7 @@ Customer.io strongly prefers the ID field to be used as the identifier for a Per
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |      **Objects?**     |
+|        **Behaviors** | **Supported?** |      **Objects**     |
 | -------------------: | :------------: | :-------------------: |
 | **Update or Create** |        ✅       | Person, Event, Device |
 |      **Update Only** |        ✅       |         Person        |

--- a/destinations/delighted.md
+++ b/destinations/delighted.md
@@ -100,7 +100,7 @@ Delighted supports two objects: Autopilot and Survey&#x20;
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|                       Behaviors |      Supported?      |  Objects? |
+|                       Behaviors |      Supported?      |  Objects |
 | ------------------------------: | :------------------: | :-------: |
 |                          Append | :white\_check\_mark: |   Survey  |
 | Update Only, Upsert, and Mirror | :white\_check\_mark: | Autopilot |

--- a/destinations/drift.md
+++ b/destinations/drift.md
@@ -51,7 +51,7 @@ If you want to see your integrations in Drift in the future, simply navigate to 
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 

--- a/destinations/facebook-ads.md
+++ b/destinations/facebook-ads.md
@@ -178,7 +178,7 @@ Please [contact us](mailto:support@getcensus.com) if there are additional Facebo
 
 ## 🔄 Supported Sync Behaviors
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |   Audiences  |
 |           **Mirror** |        ✅       |   Audiences  |

--- a/destinations/freshdesk.md
+++ b/destinations/freshdesk.md
@@ -20,7 +20,7 @@ description: This page describes how to use Census with Freshdesk.
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 

--- a/destinations/front.md
+++ b/destinations/front.md
@@ -139,7 +139,7 @@ Front has [many objects available via their API](https://dev.frontapp.com/refere
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       | Contact Only |
 |      **Update Only** |       🔜       |              |

--- a/destinations/gainsight.md
+++ b/destinations/gainsight.md
@@ -128,7 +128,7 @@ That's it, in 4 steps you have connected your Data Source to Gainsight! :tada:
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |        **Objects?**       |
+|        **Behaviors** | **Supported?** |        **Objects**       |
 | -------------------: | :------------: | :-----------------------: |
 | **Update or Create** |        ✅       |            All            |
 |      **Update Only** |        ✅       | Company, Custom Objects\* |

--- a/destinations/google-ads.md
+++ b/destinations/google-ads.md
@@ -191,7 +191,7 @@ We recommend you do not use Google's Customer Match expiration setting. Census-s
 
 ## 🔄 Supported Sync Behaviors
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ---: | :---: | :---: |
 | **Update or Create** | ✅ | All |
 | **Mirror** | ✅ | Audiences |

--- a/destinations/google-analytics.md
+++ b/destinations/google-analytics.md
@@ -97,7 +97,7 @@ The available **Objects** for the Google Analytics destination are the data sets
 
 ## 🔄 Supported sync behaviors
 
-| **Behavior** | **Supported** | **Objects** |
+| **Behavior** | **Supported?** | **Objects** |
 | -----------: | :-----------: | :---------: |
 |       Mirror |       ✅       |     All     |
 

--- a/destinations/google-cloud-storage.md
+++ b/destinations/google-cloud-storage.md
@@ -91,7 +91,7 @@ When defining the **File Path** for an GCS sync, you can use variables that will
 
 ## 🔄 Supported sync behaviors
 
-| **Behavior** | **Supported** | **Objects** |
+| **Behavior** | **Supported?** | **Objects** |
 | -----------: | :-----------: | :---------: |
 |       Mirror |       ✅       |     All     |
 

--- a/destinations/google-sheets.md
+++ b/destinations/google-sheets.md
@@ -137,7 +137,7 @@ Google Sheets support is pretty straight forward!
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ------------: | :------------: | :----------: |
 |    **Mirror** |        ✅       |  Sheet Tabs  |
 

--- a/destinations/heap.io.md
+++ b/destinations/heap.io.md
@@ -112,7 +112,7 @@ Click the Next button to see the final preview, which will have a recap of what 
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|    **Behaviors** | **Supported?** |  **Objects?** |
+|    **Behaviors** | **Supported?** |  **Objects** |
 | ---------------: | :------------: | :-----------: |
 | Update or Create |        ✅       | Account, User |
 |           Append |        ✅       |     Event     |

--- a/destinations/help-scout.md
+++ b/destinations/help-scout.md
@@ -104,7 +104,7 @@ Click the **Next** button to see the final preview, which will have a recap of w
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|    **Behaviors** | **Supported?** | **Objects?** |
+|    **Behaviors** | **Supported?** | **Objects** |
 | ---------------: | :------------: | :----------: |
 | Update or Create |        ✅       |      All     |
 |      Update Only |        ✅       |      All     |

--- a/destinations/hubspot.md
+++ b/destinations/hubspot.md
@@ -159,7 +159,7 @@ Note: The custom fields you've added will not show inside Census, you'll need to
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |      All     |

--- a/destinations/intercom.md
+++ b/destinations/intercom.md
@@ -126,7 +126,7 @@ If you're finding Companies missing in Intercom after a sync, make sure the comp
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |         **Objects?**         |
+|        **Behaviors** | **Supported?** |         **Objects**         |
 | -------------------: | :------------: | :--------------------------: |
 | **Update or Create** |        ✅       | Company, Contact, Lead, User |
 |      **Update Only** |        ✅       |      Contact, Lead, User     |

--- a/destinations/iterable.md
+++ b/destinations/iterable.md
@@ -129,7 +129,7 @@ Iterable Catalogs let you create custom objects within Iterable that can be asso
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |  **Objects?** |
+|        **Behaviors** | **Supported?** |  **Objects** |
 | -------------------: | :------------: | :-----------: |
 | **Update or Create** |        ✅       | User, Catalog |
 |      **Update Only** |        ✅       |      User     |

--- a/destinations/jira.md
+++ b/destinations/jira.md
@@ -94,7 +94,7 @@ Click the Next button to see the final preview, which will have a recap of what 
 
 Jira's primary object is an Issue, which we support in Census.​
 
-| **Object Name** | **Supported** | **Identifiers** |
+| **Object Name** | **Supported?** | **Identifiers** |
 | :-------------: | :-----------: | :-------------: |
 |      Ticket     |       ✅       |    Unique ID    |
 
@@ -104,7 +104,7 @@ Jira's primary object is an Issue, which we support in Census.​
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ------------: | :------------: | :----------: |
 |    **Append** |        ✅       |    Ticket    |
 

--- a/destinations/klaviyo.md
+++ b/destinations/klaviyo.md
@@ -116,7 +116,7 @@ To update the **List** property, you'll need to provide the list **ID** or **Nam
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers**                                |
+| **Object Name** | **Supported?** | **Identifiers**                                |
 | --------------: | :-----------: | ---------------------------------------------- |
 |         Profile |       ✅       | External ID (recommended), Email, Phone Number |
 
@@ -124,7 +124,7 @@ To update the **List** property, you'll need to provide the list **ID** or **Nam
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | :---------: |
 | Update or Create |       ✅       |     All     |
 

--- a/destinations/kustomer.md
+++ b/destinations/kustomer.md
@@ -69,7 +69,7 @@ More on Kustomer's API permission scopes [here](https://help.kustomer.com/permis
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|    **Behaviors** | **Supported?** | **Objects?** |
+|    **Behaviors** | **Supported?** | **Objects** |
 | ---------------: | :------------: | :----------: |
 | Update or Create |        ✅       |      All     |
 

--- a/destinations/linkedin.md
+++ b/destinations/linkedin.md
@@ -73,7 +73,7 @@ It is required to provide a DMP Segment Id for both objects that are supported
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|    **Behaviors** | **Supported?** | **Objects?** |
+|    **Behaviors** | **Supported?** | **Objects** |
 | ---------------: | :------------: | :----------: |
 | Update or Create |        ✅       |      All     |
 |           Mirror |        ✅       |      All     |

--- a/destinations/mailchimp.md
+++ b/destinations/mailchimp.md
@@ -87,7 +87,7 @@ Mailchimp `tags` field can be set by providing an array of string values as stru
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |      All     |

--- a/destinations/marketo.md
+++ b/destinations/marketo.md
@@ -96,7 +96,7 @@ Census currently supports syncing to the following Marketo objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |             **Objects?**            |
+|        **Behaviors** | **Supported?** |             **Objects**            |
 | -------------------: | :------------: | :---------------------------------: |
 | **Update or Create** |        ✅       |                 All                 |
 |      **Update Only** |        ✅       | Lead, Named Account, Custom Objects |

--- a/destinations/microsoft-dynamics.md
+++ b/destinations/microsoft-dynamics.md
@@ -82,7 +82,7 @@ And if anything went wrong, contact the [Census support team](mailto:support@get
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers**                       |
+| **Object Name** | **Supported?** | **Identifiers**                       |
 | --------------: | :-----------: | ------------------------------------- |
 |     Entity name |       ✅       | All single-column keys for the entity |
 
@@ -93,7 +93,7 @@ All Microsoft Dynamic [entities](https://docs.microsoft.com/en-us/dynamics365/cu
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | :---------: |
 | Update or Create |       ✅       |     All     |
 

--- a/destinations/mixpanel.md
+++ b/destinations/mixpanel.md
@@ -123,7 +123,7 @@ Depending on which plan your Mixpanel is on, you may have limited ability to vie
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |         **Objects?**        |
+|        **Behaviors** | **Supported?** |         **Objects**        |
 | -------------------: | :------------: | :-------------------------: |
 | **Update or Create** |        ✅       | User Profile, Group Profile |
 |           **Append** |        ✅       |            Event            |

--- a/destinations/netsuite.md
+++ b/destinations/netsuite.md
@@ -180,7 +180,7 @@ Please note that NetSuite doesn't support the [creation of fields](../basics/cor
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |      All     |

--- a/destinations/notion.md
+++ b/destinations/notion.md
@@ -49,7 +49,7 @@ When configuring your sync, the page should look something like this 👇
 
 We support syncing data to Tables in Notion. ​
 
-| **Object Name** | **Supported** | **Identifiers** |
+| **Object Name** | **Supported?** | **Identifiers** |
 | :-------------: | :-----------: | :-------------: |
 |      Table      |       ✅       |      Title      |
 
@@ -59,7 +59,7 @@ We support syncing data to Tables in Notion. ​
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 |           **Update** |        ✅       |      All     |
 | **Update or Create** |        ✅       |      All     |

--- a/destinations/orbit.md
+++ b/destinations/orbit.md
@@ -96,7 +96,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers**              |
+| **Object Name** | **Supported?** | **Identifiers**              |
 | --------------: | :-----------: | ---------------------------- |
 |          Member |       ✅       | Name, Email, Github, Twitter |
 
@@ -108,7 +108,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |    Member    |
 

--- a/destinations/ortto.md
+++ b/destinations/ortto.md
@@ -97,7 +97,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers**    |
+| **Object Name** | **Supported?** | **Identifiers**    |
 | --------------: | :-----------: | ------------------ |
 |    Organization |       ✅       | Name, Website      |
 |          Person |       ✅       | Email, External ID |
@@ -110,7 +110,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |     **Objects?**     |
+|        **Behaviors** | **Supported?** |     **Objects**     |
 | -------------------: | :------------: | :------------------: |
 | **Update or Create** |        ✅       | Organization, Person |
 

--- a/destinations/outreach.md
+++ b/destinations/outreach.md
@@ -108,7 +108,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers**                     |
+| **Object Name** | **Supported?** | **Identifiers**                     |
 | --------------: | :-----------: | ----------------------------------- |
 |         Account |       ✅       | any Text field                      |
 |        Prospect |       ✅       | Email (recommended), any Text field |
@@ -122,7 +122,7 @@ In most cases, you won't run into any issue with sync speed based on rate limiti
 Learn about all of our sync behaviors in [Core Concepts](../basics/core-concept/#sync-behaviors).
 {% endhint %}
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | ----------- |
 | Update or Create |       ✅       | All         |
 

--- a/destinations/pardot.md
+++ b/destinations/pardot.md
@@ -111,7 +111,7 @@ On Prospect syncs, we can Lookup from the Prospect Object to a List, which creat
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 |      **Update Only** |        ✅       |   Prospect   |
 | **Update or Create** |        ✅       |   Prospect   |

--- a/destinations/pendo.md
+++ b/destinations/pendo.md
@@ -74,7 +74,7 @@ Census currently supports syncing to the following Pendo objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|   **Behaviors** | **Supported?** |   **Objects?**  |
+|   **Behaviors** | **Supported?** |   **Objects**  |
 | --------------: | :------------: | :-------------: |
 | **Update Only** |        ✅       | Account/Visitor |
 

--- a/destinations/pipedrive.md
+++ b/destinations/pipedrive.md
@@ -44,7 +44,7 @@ This part of our documentation is still under construction! If you have any ques
 
 ## 🔄 Supported Sync Behaviors
 
-|        **Behaviors** | **Supported?** |        **Objects?**        |
+|        **Behaviors** | **Supported?** |        **Objects**        |
 | -------------------: | :------------: | :------------------------: |
 | **Update or Create** |        ✅       | Organization, Person, Deal |
 |      **Update Only** |        ✅       | Organization, Person, Deal |

--- a/destinations/planhat.md
+++ b/destinations/planhat.md
@@ -64,7 +64,7 @@ Census currently supports syncing to the following Planhat objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |    **Objects?**   |
+|        **Behaviors** | **Supported?** |    **Objects**   |
 | -------------------: | :------------: | :---------------: |
 | **Update or Create** |        ✅       | Company, End User |
 

--- a/destinations/postgres.md
+++ b/destinations/postgres.md
@@ -45,7 +45,7 @@ After the connection is verified, you all tables will be exposed, but please tak
 
 We support syncing data to Tables in Postgres, but they must have a uniqueness constraint on a column. ​
 
-| **Object Name** | **Supported** |                   **Identifiers**                   |
+| **Object Name** | **Supported?** |                   **Identifiers**                   |
 | :-------------: | :-----------: | :-------------------------------------------------: |
 |      Table      |       ✅       | Primary Keys or Columns with Uniqueness Constraints |
 
@@ -55,7 +55,7 @@ We support syncing data to Tables in Postgres, but they must have a uniqueness c
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 |           **Update** |        ✅       |      All     |
 | **Update or Create** |        ✅       |      All     |

--- a/destinations/s3.md
+++ b/destinations/s3.md
@@ -139,7 +139,7 @@ When defining the **File Path** for an S3 sync, you can use variables that will 
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | :---------: |
 | Update or Create |       ✅       |     All     |
 |           Mirror |       ✅       |     All     |

--- a/destinations/sailthru.md
+++ b/destinations/sailthru.md
@@ -96,7 +96,7 @@ And if anything went wrong, contact the [Census support team](mailto:support@get
 
 ## 🗄 Supported objects
 
-| **Object Name** | **Supported** | **Identifiers** |
+| **Object Name** | **Supported?** | **Identifiers** |
 | --------------: | :-----------: | --------------- |
 |            User |       ✅       | Email           |
 |            List |       🔜      |                 |
@@ -105,7 +105,7 @@ And if anything went wrong, contact the [Census support team](mailto:support@get
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | :---------: |
 | Update or Create |       ✅       |     User    |
 |      Update Only |      `✅`      |     User    |

--- a/destinations/salesforce-marketing-cloud.md
+++ b/destinations/salesforce-marketing-cloud.md
@@ -161,7 +161,7 @@ You're ready to start using Census to load data from your warehouse to Salesforc
 Learn more about all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |           **Mirror** |        ✅       |      All     |

--- a/destinations/segment.md
+++ b/destinations/segment.md
@@ -132,7 +132,7 @@ For more information on the meaning of different Segment fields, take a look at 
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |  **Objects?** |
+|        **Behaviors** | **Supported?** |  **Objects** |
 | -------------------: | :------------: | :-----------: |
 | **Update or Create** |        ✅       |      User     |
 |           **Append** |        ✅       | Track (Event) |

--- a/destinations/sendgrid.md
+++ b/destinations/sendgrid.md
@@ -65,7 +65,7 @@ Census currently supports syncing to the following SendGrid objects.
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** |  **Objects?** |
+|        **Behaviors** | **Supported?** |  **Objects** |
 | -------------------: | :------------: | :-----------: |
 | **Update or Create** |        ✅       | Contact, List |
 |      **Update Only** |        ✅       |    Contact    |

--- a/destinations/sftp.md
+++ b/destinations/sftp.md
@@ -115,7 +115,7 @@ When defining the **File Path** for an S3 sync, you can use variables that will 
 
 ## 🔄 Supported sync behaviors
 
-|    **Behaviors** | **Supported** | **Objects** |
+|    **Behaviors** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | :---------: |
 | Update or Create |       ✅       |     All     |
 |           Mirror |       ✅       |     All     |

--- a/destinations/shopify.md
+++ b/destinations/shopify.md
@@ -65,7 +65,7 @@ Only the `src` field is required. `position`, `width`, and `height` are optional
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|    **Behaviors** | **Supported?** |    **Objects?**   |
+|    **Behaviors** | **Supported?** |    **Objects**   |
 | ---------------: | :------------: | :---------------: |
 | Update or Create |        ✅       | Customer, Product |
 |           Mirror |        ✅       |  Product Variant  |

--- a/destinations/slack.md
+++ b/destinations/slack.md
@@ -138,7 +138,7 @@ Census can send data to **all** public channels and any private channels that Ce
 
 ## 🔄 Supported Sync Behaviors
 
-| **Behaviors** | **Supported?** | **Objects?** |
+| **Behaviors** | **Supported?** | **Objects** |
 | ------------: | :------------: | :----------: |
 |    **Append** |        ✅       |    channel   |
 

--- a/destinations/snapchat.md
+++ b/destinations/snapchat.md
@@ -68,7 +68,7 @@ Follow Snapchat OAuth flow to connect to your Snapchat account.&#x20;
 
 ## 🔄 Supported Sync Behaviors
 
-|     Behaviors    |      Supported?      |     Objects?    |
+|     Behaviors    |      Supported?      |     Objects    |
 | :--------------: | :------------------: | :-------------: |
 | Update or Create | :white\_check\_mark: | Segments, Users |
 |      Mirror      | :white\_check\_mark: |      Users      |

--- a/destinations/stripe.md
+++ b/destinations/stripe.md
@@ -116,7 +116,7 @@ Census currently supports syncing to the following Stripe objects:
 Learn more about all of our sync behaviors on our [Core Concepts page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |      **Update Only** |        ✅       |      All     |

--- a/destinations/twitter.md
+++ b/destinations/twitter.md
@@ -94,7 +94,7 @@ To use this setting, you'll also need to include a column in your database/data 
 
 ## 🗄 Supported objects
 
-|  **Object Name** | **Supported** | **Identifiers**                                                        |
+|  **Object Name** | **Supported?** | **Identifiers**                                                        |
 | ---------------: | :-----------: | ---------------------------------------------------------------------- |
 |         Audience |       ✅       | Email, Handle, Device ID                                               |
 | Conversion Event |       ✅       | App ID, Conversion Time, Conversion Type, Hashed Device ID, OS Typees} |
@@ -103,7 +103,7 @@ To use this setting, you'll also need to include a column in your database/data 
 
 ## 🔄 Supported sync behaviors
 
-| **Behavior** | **Supported** |    **Objects**   |
+| **Behavior** | **Supported?** |    **Objects**   |
 | -----------: | :-----------: | :--------------: |
 |       Append |       ✅       | Conversion Event |
 |       Mirror |       ✅       |     Audience     |

--- a/destinations/webhook.md
+++ b/destinations/webhook.md
@@ -155,7 +155,7 @@ Each webhook `POST` contains both the data you mapped as well as metadata about 
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-|        **Behaviors** | **Supported?** | **Objects?** |
+|        **Behaviors** | **Supported?** | **Objects** |
 | -------------------: | :------------: | :----------: |
 | **Update or Create** |        ✅       |      All     |
 |           **Append** |        ✅       |      All     |

--- a/destinations/zendesk.md
+++ b/destinations/zendesk.md
@@ -147,7 +147,7 @@ lower(replace(column_name, ' ', '_'))
 
 Census currently supports syncing to the following Zendesk objects:
 
-| **Object Name** | **Supported** | **Identifiers**                  |
+| **Object Name** | **Supported?** | **Identifiers**                  |
 | --------------: | :-----------: | -------------------------------- |
 |        End User |       ✅       | External ID (recommended), Email |
 |    Organization |       ✅       | External ID (recommended), Name  |
@@ -160,7 +160,7 @@ Please note that Zendesk requires the `Name` property for the End User object. F
 
 ## 🔄 Supported sync behaviors
 
-|     **Behavior** | **Supported** | **Objects** |
+|     **Behavior** | **Supported?** | **Objects** |
 | ---------------: | :-----------: | ----------- |
 | Update or Create |       ✅       | All         |
 |      Update Only |       ✅       | All         |

--- a/destinations/zuora.md
+++ b/destinations/zuora.md
@@ -112,7 +112,7 @@ Click the **Next** button to see the final preview, which will have a recap of w
 Learn more about what all of our sync behaviors on our [Core Concept page](../basics/core-concept/#the-different-sync-behaviors).
 {% endhint %}
 
-| **Behaviors** | **Supported?** |      **Objects?**     |
+| **Behaviors** | **Supported?** |      **Objects**     |
 | ------------: | :------------: | :-------------------: |
 |   Update Only |        ✅       | Account, Subscription |
 


### PR DESCRIPTION
## Description of the change

I noticed that in some places we use "Objects?" and "Supported" in table headers yet in others it's "Objects" and "Supported?". I couldn't walk away (thank you, my personal OCD). Mass replaced everything to be consistent:
- Supported -> Supported?
- Objects? -> Objects

Command:
```
$ find . -type f -name '*.md' -exec sed -i '' s/Supported\*\*/Supported\?\*\*/g {} +
```

A couple of examples below.

Amplitude:
![image](https://user-images.githubusercontent.com/198995/185010044-672ea98c-2a56-4b28-89e3-96aaec0c78cc.png)

Criteo:
![image](https://user-images.githubusercontent.com/198995/185010086-f37042d8-1b98-4d94-8f9a-f7e2fad900a2.png)

## How tested

Not tested.

## Security implications

n/a
