### PR TITLE
Add AWS Account ID directly into docs

### DIFF
--- a/basics/security-and-privacy/configuring-census-to-use-an-s3-bucket-you-control.md
+++ b/basics/security-and-privacy/configuring-census-to-use-an-s3-bucket-you-control.md
@@ -14,7 +14,7 @@ _This feature is not currently available at all Census subscription levels or fo
 
 This guide will take you through the steps to prepare a bucket for use with Census. We will use the `aws` CLI to create and configure your bucket - you should [install this tool and configure it to use your credentials](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) before starting. Similar configuration is also possible using the AWS Console UI but those instructions are not provided here.
 
-In order to proceed, you will also need the Census AWS Account ID and your customer-owned bucket External ID - these will be provided to you by your Census representative.
+In order to proceed, you will also need the Census AWS Account ID (`341876425553`) and your customer-owned bucket External ID - these will be provided to you by your Census representative.
 
 ### 1. Choose a bucket name
 
@@ -71,7 +71,7 @@ First, create an empty role with a policy that allows Census to assume it via AW
 
 ```
 aws iam create-role --role-name census-data-warehouse-client --assume-role-policy-document \
-  '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"sts:AssumeRole","Principal":{"AWS":"'$CENSUS_AWS_ACCOUNT_ID'"},"Condition":{"StringEquals":{"sts:ExternalId":"'$CENSUS_CUSTOMER_BUCKET_EXTERNAL_ID'"}}}}'
+  '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"sts:AssumeRole","Principal":{"AWS":"'341876425553'"},"Condition":{"StringEquals":{"sts:ExternalId":"'$CENSUS_CUSTOMER_BUCKET_EXTERNAL_ID'"}}}}'
 ```
 
 This command should print out a role document that looks something like this:

--- a/destinations/amazon-eventbridge.md
+++ b/destinations/amazon-eventbridge.md
@@ -14,7 +14,7 @@ Creating an IAM Role with the necessary permissions requires a few steps in the 
 
 * Open your AWS Console in a separate tab and browse to the **IAM** service. Click **Roles** and **Create role**.
 * When creating the role choose **AWS Account** for **Trusted Entity Type** and the **Another AWS Account** radio button.
-* Ask your Census account representative for the Census AWS account to use.
+* Provide Census's AWS Account ID: `341876425553`.
 * Select the policy&#x20;
   * For services that write to EventBridge, [AWS recommends](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-identity-based.html#eb-events-iam-roles) the `AmazonEventBridgeFullAccess` and this is the only pre-made policy offering the necessary permissions.&#x20;
   * You can also use any custom policy that includes the `events:PutEvents` and `events:ListEventBuses` actions.&#x20;

--- a/destinations/s3.md
+++ b/destinations/s3.md
@@ -44,7 +44,7 @@ Step 3: Click the 'Back' button to return to editing the destination. You should
 Step 4: Open your AWS Console in a separate tab and browse to the IAM service. Click 'Roles' and 'Create role'.
 
 * When creating the role choose 'AWS Account' for Trusted Entity Type and the 'Another AWS Account' radio button.
-* Ask your Census account representative for the Census AWS account to use.
+* Provide Census's AWS Account ID: `341876425553`.
 * Check the 'Require external ID' checkbox and enter the External ID string from Step 3.
 * Finish setting up your Role. Note that it should have the [required permissions](s3.md#required-permissions) to access the bucket you are using as your Census destination!
 * When done, click on your role and copy its ARN. Go back to the tab where you're editing the Census S3 Destination and enter the role ARN.

--- a/sources/aws-athena.md
+++ b/sources/aws-athena.md
@@ -71,7 +71,7 @@ Here is a sample IAM policy that specifies the resources:
                 "arn:aws:glue:<region>:<aws-account-id>:database/<database of tables to sync>",
                 "arn:aws:glue:<region>:<aws-account-id>:catalog",
                 "arn:aws:athena:<region>:<aws-account-id>:workgroup/<workgroup>", # <---- only necessary if workgroup is not primary
-                "arn:aws:athena:<region>:<aws-account-id>:workgroup/primary", 
+                "arn:aws:athena:<region>:<aws-account-id>:workgroup/primary",
                 "arn:aws:s3:::<query-results-bucket>",
                 "arn:aws:s3:::<query-results-bucket>/*",
                 "arn:aws:s3:::<arn where table lives>",
@@ -109,7 +109,7 @@ Step 3: Click the 'Back' button to return to editing the destination. You should
 Step 4: Open your AWS Console in a separate tab and browse to the IAM service. Click 'Roles' and 'Create role'.
 
 * When creating the role choose 'AWS Account' for Trusted Entity Type and the 'Another AWS Account' radio button.
-* Ask your Census account representative for the Census AWS account to use.
+* Provide Census's AWS Account ID: `341876425553`.
 * Check the 'Require external ID' checkbox and enter the External ID string from Step 3.
 * Finish setting up your Role. Note that it should have the [required permissions](aws-athena.md#required-permissions) to access the Athena instance and associated S3 buckets you are using as your Census source!
 * When done, click on your role and copy its ARN. Go back to the tab where you're editing the Census Athena source and enter the role ARN.

--- a/sources/s3.md
+++ b/sources/s3.md
@@ -27,14 +27,7 @@ Census uses role-based authentication to connect to your bucket, as [recommended
 These examples use the AWS CLI, but you can use the AWS Console, API, Terraform, or other tools instead to accomplish the same setup tasks.
 {% endhint %}
 
-1.  Get your AWS Account ID; you'll use this to create a placeholder AssumeRolePolicy that we will replace with the Census AWS Account ID in a later step:
-
-    ```sh
-    aws sts get-caller-identity
-    ```
-
-    Use the `Account` value here (a 12-digit number) in the next step (replacing `${YOUR_AWS_ACCOUNT_NUMBER}`).
-2.  Create an IAM role in your AWS account that provides read-only access to your S3 bucket and prefix. Throughout this example, we'll assume that your bucket name is `census-docs-example`, your region is `us-east-1`, and your prefix is `data/`:
+1.  Create an IAM role in your AWS account that provides read-only access to your S3 bucket and prefix for Census's AWS Account ID (`341876425553`). Throughout this example, we'll assume that your bucket name is `census-docs-example`, your region is `us-east-1`, and your prefix is `data/`:
 
     ```sh
     aws iam create-role \
@@ -43,14 +36,14 @@ These examples use the AWS CLI, but you can use the AWS Console, API, Terraform,
         "Version": "2012-10-17",
         "Statement": [{
           "Effect": "Allow",
-          "Principal": {"AWS": "arn:aws:iam::${YOUR_AWS_ACCOUNT_NUMBER}:root"},
+          "Principal": {"AWS": "arn:aws:iam::341876425553:root"},
           "Action": "sts:AssumeRole"
         }]
       }'
     ```
 
-    This will return a JSON document containing an `Arn` for the role you just created - something like `"arn:aws:iam::${YOUR_AWS_ACCOUNT_NUMBER}:role/CensusReadOnlyToS3"`. Keep track of this role ARN because you will need it throughout the rest of the setup process.
-3.  Grant your newly-created role read-only access to your S3 bucket. We'll do this using an inline policy, but there are many ways to manage permissions in AWS IAM, so choose the appropriate technique for your organization's needs.
+    This will return a JSON document containing an `Arn` for the role you just created - something like `"arn:aws:iam::341876425553:role/CensusReadOnlyToS3"`. Keep track of this role ARN because you will need it throughout the rest of the setup process.
+2.  Grant your newly-created role read-only access to your S3 bucket. We'll do this using an inline policy, but there are many ways to manage permissions in AWS IAM, so choose the appropriate technique for your organization's needs.
 
     ```sh
     aws iam put-role-policy \
@@ -75,9 +68,9 @@ These examples use the AWS CLI, but you can use the AWS Console, API, Terraform,
     ```
 
     It's possible to further restrict this role to limit Census' access by object prefix, though we recommend using a dedicated bucket for sharing data with Census to keep roles and permissions simple.
-4. Navigate to the Census [Sources tab](https://app.getcensus.com/sources) and click "New Source", then select "S3" in the menu.
-5. Provide the **Region**, **Bucket Name**, **Role ARN**, and **Prefix** to Census, and click "Connect".
-6.  Census will generate a unique external ID (`${CENSUS_EXTERNAL_ID}`) that helps secure the connection between your role and the Census AWS account (`${CENSUS_AWS_ACCOUNT_NUMBER}`) and display it on the next screen. Update your role to grant access to the Census AWS Account (instead of your own) and to require this external ID for all API calls:
+3. Navigate to the Census [Sources tab](https://app.getcensus.com/sources) and click "New Source", then select "S3" in the menu.
+4. Provide the **Region**, **Bucket Name**, **Role ARN**, and **Prefix** to Census, and click "Connect".
+5.  Census will generate a unique external ID (`${CENSUS_EXTERNAL_ID}`) and display it on the next screen. It helps secure the connection between your role and the Census AWS account. Update your role to grant access to the Census AWS Account (instead of your own) and to require this external ID for all API calls:
 
     ```sh
     aws iam update-assume-role-policy \
@@ -86,13 +79,13 @@ These examples use the AWS CLI, but you can use the AWS Console, API, Terraform,
         "Version": "2012-10-17",
         "Statement": [{
           "Effect": "Allow",
-          "Principal": {"AWS": "arn:aws:iam::${CENSUS_AWS_ACCOUNT_NUMBER}:root"},
+          "Principal": {"AWS": "arn:aws:iam::341876425553:root"},
           "Action": "sts:AssumeRole",
           "Condition": {"StringEquals": {"sts:ExternalId": "${CENSUS_EXTERNAL_ID}"}}
         }]
       }'
     ```
-7. Click the "Test" button in the Census UI to verify that the connection has been configured successfully.
+6. Click the "Test" button in the Census UI to verify that the connection has been configured successfully.
 
 ## CSV Processing Modes
 


### PR DESCRIPTION
## Description of the change

Put AWS Account ID directly into docs to save support back and forth

## Security implications

Cleared with Brad 
